### PR TITLE
ci: use cached vscode at E2E tests

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -40,6 +40,13 @@ jobs:
                   path: .
                   filename: vscode-webdriverio-build.zip
 
+            - name: Restore cached vscode
+              id: cache-vscode-restore
+              uses: actions/cache@v4
+              with:
+                  path: e2e/.wdio-vscode-service
+                  key: ${{ runner.os }}-vscode
+
             - name: 🧪 Run the e2e test
               env:
                   VSCODE_WDIO_E2E_COMPATIBILITY_MODE: ${{ inputs.compatibility-mode }}

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -35,9 +35,24 @@ jobs:
                   path: .
                   filename: vscode-webdriverio-build.zip
 
+            - name: 🗃️ Restore cached vscode
+              id: cache-vscode-restore
+              uses: actions/cache@v4
+              with:
+                  path: e2e/.wdio-vscode-service
+                  key: ${{ runner.os }}-vscode
+
             - name: 🚂 Run the smoke test
               run: pnpm run test:smoke
               shell: bash
+
+            - name: 📦 Upload Test Logs on Failure
+              uses: ./.github/workflows/actions/upload-archive
+              if: failure()
+              with:
+                  name: smoke-logs-${{ matrix.os }}
+                  output: smoke-logs-${{ matrix.os }}.zip
+                  paths: e2e/logs
 
             - name: 🐛 Debug Build
               uses: stateful/vscode-server-action@v1.1.0

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -18,40 +18,47 @@ process.env.VSCODE_WDIO_TRACE_LOG_PATH = outputDir
 
 const specs = target === 'cucumber' ? ['./tests/basicCucumber.spec.ts'] : ['./tests/basic.spec.ts']
 
-export const config: WebdriverIO.Config = {
-    runner: 'local',
-    tsConfigPath: './tsconfig.json',
-    specs,
-    maxInstances: 10,
-    capabilities: [
-        {
-            browserName: 'vscode',
-            browserVersion: version,
-            'wdio:vscodeOptions': {
-                // points to directory where extension package.json is located
-                extensionPath: path.resolve('../packages/vscode-webdriverio'),
-                // optional VS Code settings
-                userSettings: {
-                    'webdriverio.logLevel': 'trace',
+export function createBaseConfig(workspacePath: string): WebdriverIO.Config {
+    return {
+        runner: 'local',
+        tsConfigPath: './tsconfig.json',
+        specs,
+        maxInstances: 10,
+        capabilities: [
+            {
+                browserName: 'vscode',
+                browserVersion: version,
+                'wdio:vscodeOptions': {
+                    // points to directory where extension package.json is located
+                    extensionPath: path.resolve('../packages/vscode-webdriverio'),
+                    // optional VS Code settings
+                    userSettings: {
+                        'webdriverio.logLevel': 'trace',
+                    },
+                    workspacePath: path.resolve(workspacePath),
                 },
-                workspacePath: path.resolve(`../samples/e2e/${target}`),
+                'wdio:enforceWebDriverClassic': true,
             },
-            'wdio:enforceWebDriverClassic': true,
-        },
-    ],
+        ],
 
-    logLevel: 'debug',
-    outputDir,
-    bail: 0,
-    waitforTimeout: 120000,
-    connectionRetryTimeout: 120000,
-    connectionRetryCount: 3,
-    services: ['vscode'],
-    framework: 'mocha',
-    reporters: ['spec'],
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 6000000,
-        require: ['assertions/index.ts'],
-    },
+        logLevel: 'debug',
+        outputDir,
+        bail: 0,
+        waitforTimeout: 120000,
+        connectionRetryTimeout: 120000,
+        connectionRetryCount: 3,
+        services: [['vscode', { cachePath: path.join(__dirname, '.wdio-vscode-service') }]],
+        framework: 'mocha',
+        reporters: ['spec'],
+        mochaOpts: {
+            ui: 'bdd',
+            timeout: 6000000,
+            require: ['assertions/index.ts'],
+        },
+    }
+}
+
+export const config: WebdriverIO.Config = {
+    ...createBaseConfig(`../samples/e2e/${target}`),
+    specs,
 }

--- a/e2e/wdioSmoke.conf.ts
+++ b/e2e/wdioSmoke.conf.ts
@@ -1,41 +1,8 @@
-import * as path from 'node:path'
+import { createBaseConfig } from './wdio.conf.ts'
 
 const specs = ['./tests/updateConfig.spec.ts']
 
 export const config: WebdriverIO.Config = {
-    runner: 'local',
-    tsConfigPath: './tsconfig.json',
+    ...createBaseConfig('../samples/smoke/update-config'),
     specs,
-    maxInstances: 10,
-    capabilities: [
-        {
-            browserName: 'vscode',
-            browserVersion: 'stable', // also possible: "insiders" or a specific version e.g. "1.80.0"
-            'wdio:vscodeOptions': {
-                // points to directory where extension package.json is located
-                extensionPath: path.resolve('../packages/vscode-webdriverio'),
-                // optional VS Code settings
-                userSettings: {
-                    'webdriverio.logLevel': 'trace',
-                },
-                workspacePath: path.resolve('../samples/smoke/update-config'),
-            },
-            'wdio:enforceWebDriverClassic': true,
-        },
-    ],
-
-    logLevel: 'debug',
-    outputDir: 'logs',
-    bail: 0,
-    waitforTimeout: 120000,
-    connectionRetryTimeout: 120000,
-    connectionRetryCount: 3,
-    services: ['vscode'],
-    framework: 'mocha',
-    reporters: ['spec'],
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 6000000,
-        require: ['assertions/index.ts'],
-    },
 }


### PR DESCRIPTION
## Proposed changes

To reduce time of CI, cache the vscode binalies.

## Types of changes

[//]: # 'What types of changes does your code introduce to WebdriverIO?'
[//]: # '_Put an `x` in the boxes that apply_'

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [X] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # "_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._"

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/vscode-webdriverio/blob/main/CONTRIBUTION.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # 'If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...'

### Reviewers: @webdriverio/project-committers
