### PR TITLE
feat: module separation of worker module

### DIFF
--- a/packages/vscode-wdio-worker/package.json
+++ b/packages/vscode-wdio-worker/package.json
@@ -10,6 +10,9 @@
         "./windows": {
             "import": "./dist/config.js"
         },
+        "./parser/ast": {
+            "import": "./dist/parsers/js.js"
+        },
         "./parser/cucumber": {
             "import": "./dist/parsers/cucumber.js"
         }

--- a/packages/vscode-wdio-worker/package.json
+++ b/packages/vscode-wdio-worker/package.json
@@ -9,6 +9,9 @@
         },
         "./windows": {
             "import": "./dist/config.js"
+        },
+        "./parser/cucumber": {
+            "import": "./dist/parsers/cucumber.js"
         }
     },
     "scripts": {

--- a/packages/vscode-wdio-worker/package.json
+++ b/packages/vscode-wdio-worker/package.json
@@ -6,6 +6,9 @@
     "exports": {
         ".": {
             "import": "./dist/index.js"
+        },
+        "./windows": {
+            "import": "./dist/config.js"
         }
     },
     "scripts": {

--- a/packages/vscode-wdio-worker/src/config.ts
+++ b/packages/vscode-wdio-worker/src/config.ts
@@ -7,7 +7,10 @@ import * as t from '@babel/types'
 import recast from 'recast'
 
 const reporterIdentifierName = 'VscodeJsonReporter'
-const VSCODE_REPORTER_PATH = path.resolve(__dirname, 'reporter.cjs')
+
+// This file is bundle as parser/ats.js at the package of vscode-webdriverio
+// So, the correct reporter path is parent directory
+const VSCODE_REPORTER_PATH = path.resolve(__dirname, '../reporter.cjs')
 /**
  * Since Windows cannot import by reporter file path due to issues with
  * the `initializePlugin` method of wdio-utils, the policy is to create a temporary configuration file.

--- a/packages/vscode-wdio-worker/src/parsers/cucumber.ts
+++ b/packages/vscode-wdio-worker/src/parsers/cucumber.ts
@@ -12,7 +12,7 @@ import type { CucumberTestData, StepType, WorkerMetaContext } from '@vscode-wdio
  * @returns Array of test case information
  */
 export function parseCucumberFeature(this: WorkerMetaContext, fileContent: string, uri: string) {
-    this.log.debug('Cucumber parser is used.')
+    this.log.debug(`Start parsing the cucumber feature file: ${uri}`)
     try {
         // Initialize the parser components
         const builder = new AstBuilder(IdGenerator.uuid())

--- a/packages/vscode-wdio-worker/src/parsers/index.ts
+++ b/packages/vscode-wdio-worker/src/parsers/index.ts
@@ -1,13 +1,17 @@
 import * as fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { parseTestCases } from './js.js'
-import { getCucumberParser } from './utils.js'
+import { getAstParser, getCucumberParser } from './utils.js'
 import type { ReadSpecsOptions } from '@vscode-wdio/types/api'
 import type { WorkerMetaContext } from '@vscode-wdio/types/worker'
 
 async function parseFeatureFile(context: WorkerMetaContext, contents: string, normalizeSpecPath: string) {
     const p = await getCucumberParser(context)
+    return p.call(context, contents, normalizeSpecPath)
+}
+
+async function parseJsFile(context: WorkerMetaContext, contents: string, normalizeSpecPath: string) {
+    const p = await getAstParser(context)
     return p.call(context, contents, normalizeSpecPath)
 }
 
@@ -20,7 +24,7 @@ export async function parse(this: WorkerMetaContext, options: ReadSpecsOptions) 
             try {
                 const testCases = isCucumberFeatureFile(normalizeSpecPath)
                     ? await parseFeatureFile(this, contents, normalizeSpecPath) // Parse Cucumber feature file
-                    : parseTestCases.call(this, contents, normalizeSpecPath) // Parse JavaScript/TypeScript test file
+                    : await parseJsFile(this, contents, normalizeSpecPath) // Parse JavaScript/TypeScript test file
 
                 this.log.debug(`Successfully parsed: ${normalizeSpecPath}`)
                 return {

--- a/packages/vscode-wdio-worker/src/parsers/utils.ts
+++ b/packages/vscode-wdio-worker/src/parsers/utils.ts
@@ -1,0 +1,20 @@
+import path from 'node:path'
+
+import type { WorkerMetaContext } from '@vscode-wdio/types/worker'
+import type { parseCucumberFeature } from './cucumber.js'
+
+export type CucumberParser = typeof parseCucumberFeature
+
+const CUCUMBER_PARSER_PATH = path.resolve(__dirname, 'parser/cucumber.cjs')
+
+let cucumberParser: CucumberParser | undefined
+
+export async function getCucumberParser(context: WorkerMetaContext): Promise<CucumberParser> {
+    if (cucumberParser) {
+        context.log.debug('Use cached Cucumber parser')
+        return cucumberParser
+    }
+    context.log.debug('Import Cucumber parser')
+    cucumberParser = (await import(CUCUMBER_PARSER_PATH)).parseCucumberFeature as CucumberParser
+    return cucumberParser
+}

--- a/packages/vscode-wdio-worker/src/parsers/utils.ts
+++ b/packages/vscode-wdio-worker/src/parsers/utils.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import { dynamicLoader } from '../utils.js'
 import type { WorkerMetaContext } from '@vscode-wdio/types/worker'
 import type { parseCucumberFeature } from './cucumber.js'
 import type { parseTestCases } from './js.js'
@@ -14,21 +15,14 @@ let cucumberParser: CucumberParser | undefined
 let astParser: AstParser | undefined
 
 export async function getCucumberParser(context: WorkerMetaContext): Promise<CucumberParser> {
-    if (cucumberParser) {
-        context.log.debug('Use cached Cucumber parser')
-        return cucumberParser
-    }
-    context.log.debug('Import Cucumber parser')
-    cucumberParser = (await import(CUCUMBER_PARSER_PATH)).parseCucumberFeature as CucumberParser
-    return cucumberParser
+    return (await dynamicLoader(
+        context,
+        cucumberParser,
+        CUCUMBER_PARSER_PATH,
+        'parseCucumberFeature'
+    )) as CucumberParser
 }
 
 export async function getAstParser(context: WorkerMetaContext): Promise<AstParser> {
-    if (astParser) {
-        context.log.debug('Use cached Ast parser')
-        return astParser
-    }
-    context.log.debug('Import Ast parser')
-    astParser = (await import(AST_PARSER_PATH)).parseTestCases as AstParser
-    return astParser
+    return (await dynamicLoader(context, astParser, AST_PARSER_PATH, 'parseTestCases')) as AstParser
 }

--- a/packages/vscode-wdio-worker/src/parsers/utils.ts
+++ b/packages/vscode-wdio-worker/src/parsers/utils.ts
@@ -2,12 +2,16 @@ import path from 'node:path'
 
 import type { WorkerMetaContext } from '@vscode-wdio/types/worker'
 import type { parseCucumberFeature } from './cucumber.js'
+import type { parseTestCases } from './js.js'
 
 export type CucumberParser = typeof parseCucumberFeature
+export type AstParser = typeof parseTestCases
 
 const CUCUMBER_PARSER_PATH = path.resolve(__dirname, 'parser/cucumber.cjs')
+const AST_PARSER_PATH = path.resolve(__dirname, 'parser/ast.cjs')
 
 let cucumberParser: CucumberParser | undefined
+let astParser: AstParser | undefined
 
 export async function getCucumberParser(context: WorkerMetaContext): Promise<CucumberParser> {
     if (cucumberParser) {
@@ -17,4 +21,14 @@ export async function getCucumberParser(context: WorkerMetaContext): Promise<Cuc
     context.log.debug('Import Cucumber parser')
     cucumberParser = (await import(CUCUMBER_PARSER_PATH)).parseCucumberFeature as CucumberParser
     return cucumberParser
+}
+
+export async function getAstParser(context: WorkerMetaContext): Promise<AstParser> {
+    if (astParser) {
+        context.log.debug('Use cached Ast parser')
+        return astParser
+    }
+    context.log.debug('Import Ast parser')
+    astParser = (await import(AST_PARSER_PATH)).parseTestCases as AstParser
+    return astParser
 }

--- a/packages/vscode-wdio-worker/src/test.ts
+++ b/packages/vscode-wdio-worker/src/test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 
 import { getLauncherInstance } from './cli.js'
-import { createTempConfigFile, isWindows } from './config.js'
+import { getTempConfigCreator, isWindows } from './utils.js'
 import type { RunTestOptions, TestResultData } from '@vscode-wdio/types/api'
 import type { ResultSet } from '@vscode-wdio/types/reporter'
 import type { LoggerInterface } from '@vscode-wdio/types/utils'
@@ -43,7 +43,8 @@ export async function runTest(this: WorkerMetaContext, options: RunTestOptions):
         }
 
         if (isWindows()) {
-            configFile = await createTempConfigFile(options.configPath, outputDir.json!)
+            const creator = await getTempConfigCreator(this)
+            configFile = await creator(options.configPath, outputDir.json!)
             options.configPath = configFile
             wdioArgs.configPath = configFile
         }

--- a/packages/vscode-wdio-worker/src/utils.ts
+++ b/packages/vscode-wdio-worker/src/utils.ts
@@ -10,14 +10,13 @@ const VSCODE_WINDOWS_CONFIG_CREATOR_PATH = path.resolve(__dirname, 'parser/ast.c
 let tempConfigCreator: TempConfigFileCreator | undefined
 
 export async function getTempConfigCreator(context: WorkerMetaContext): Promise<TempConfigFileCreator> {
-    if (tempConfigCreator){
+    if (tempConfigCreator) {
         context.log.debug('Use cached TempConfigFileCreator')
         return tempConfigCreator
     }
     context.log.debug('Import TempConfigFileCreator')
-    tempConfigCreator =((await import(VSCODE_WINDOWS_CONFIG_CREATOR_PATH)).createTempConfigFile as TempConfigFileCreator)
+    tempConfigCreator = (await import(VSCODE_WINDOWS_CONFIG_CREATOR_PATH)).createTempConfigFile as TempConfigFileCreator
     return tempConfigCreator
-
 }
 
 export function isWindows() {

--- a/packages/vscode-wdio-worker/src/utils.ts
+++ b/packages/vscode-wdio-worker/src/utils.ts
@@ -1,0 +1,25 @@
+import path from 'node:path'
+
+import type { WorkerMetaContext } from '@vscode-wdio/types'
+import type { createTempConfigFile } from './config.js'
+
+export type TempConfigFileCreator = typeof createTempConfigFile
+
+const VSCODE_WINDOWS_CONFIG_CREATOR_PATH = path.resolve(__dirname, 'parser/ast.cjs')
+
+let tempConfigCreator: TempConfigFileCreator | undefined
+
+export async function getTempConfigCreator(context: WorkerMetaContext): Promise<TempConfigFileCreator> {
+    if (tempConfigCreator){
+        context.log.debug('Use cached TempConfigFileCreator')
+        return tempConfigCreator
+    }
+    context.log.debug('Import TempConfigFileCreator')
+    tempConfigCreator =((await import(VSCODE_WINDOWS_CONFIG_CREATOR_PATH)).createTempConfigFile as TempConfigFileCreator)
+    return tempConfigCreator
+
+}
+
+export function isWindows() {
+    return process.platform === 'win32'
+}

--- a/packages/vscode-wdio-worker/tests/config.test.ts
+++ b/packages/vscode-wdio-worker/tests/config.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { resolve as winResolve } from 'node:path/posix'
 import { pathToFileURL } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -27,7 +26,7 @@ vi.mock('node:path', async (importOriginal) => {
     return {
         default: {
             ...actual,
-            resolve: vi.fn((_, f) => winResolve(`/path/to/parser/${f}`)),
+            resolve: vi.fn((_, f) => path.posix.resolve(`/path/to/parser/${f}`)),
         },
     }
 })

--- a/packages/vscode-wdio-worker/tests/config.test.ts
+++ b/packages/vscode-wdio-worker/tests/config.test.ts
@@ -26,13 +26,13 @@ vi.mock('node:path', async (importOriginal) => {
     return {
         default: {
             ...actual,
-            resolve: vi.fn((_, f) => `/path/to/${f}`),
+            resolve: vi.fn((_, f) => actual.resolve(`/path/to/parser/${f}`)),
         },
     }
 })
 
 describe('config.ts', () => {
-    const VSCODE_REPORTER_PATH = path.resolve(__dirname, 'reporter.cjs')
+    const VSCODE_REPORTER_PATH = path.resolve(__dirname, '../reporter.cjs')
     const reporterPathUrl = pathToFileURL(VSCODE_REPORTER_PATH).href
 
     beforeEach(() => {

--- a/packages/vscode-wdio-worker/tests/config.test.ts
+++ b/packages/vscode-wdio-worker/tests/config.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { resolve as winResolve } from 'node:path/posix'
 import { pathToFileURL } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -26,7 +27,7 @@ vi.mock('node:path', async (importOriginal) => {
     return {
         default: {
             ...actual,
-            resolve: vi.fn((_, f) => actual.resolve(`/path/to/parser/${f}`)),
+            resolve: vi.fn((_, f) => winResolve(`/path/to/parser/${f}`)),
         },
     }
 })

--- a/packages/vscode-wdio-worker/tests/parsers/cucumber.test.ts
+++ b/packages/vscode-wdio-worker/tests/parsers/cucumber.test.ts
@@ -340,7 +340,9 @@ describe('Cucumber Parser', () => {
             parseCucumberFeature.call(mockContext, basicFeatureContent, 'basic-feature.feature')
 
             // Verify debug log was called
-            expect(mockContext.log.debug).toHaveBeenCalledWith('Cucumber parser is used.')
+            expect(mockContext.log.debug).toHaveBeenCalledWith(
+                'Start parsing the cucumber feature file: basic-feature.feature'
+            )
         })
 
         it('should include proper source ranges for each element', () => {

--- a/packages/vscode-wdio-worker/tests/parsers/index.test.ts
+++ b/packages/vscode-wdio-worker/tests/parsers/index.test.ts
@@ -52,7 +52,7 @@ describe('Parser Index', () => {
             ],
         },
     ]
-    const mockAstParser = vi.fn(()=>jsMockTestData)
+    const mockAstParser = vi.fn(() => jsMockTestData)
 
     const cucumberMockTestData: CucumberTestData[] = [
         {
@@ -81,7 +81,7 @@ describe('Parser Index', () => {
             metadata: {},
         },
     ]
-    const mockCucumberParser = vi.fn(()=>cucumberMockTestData)
+    const mockCucumberParser = vi.fn(() => cucumberMockTestData)
 
     beforeEach(() => {
         vi.resetAllMocks()

--- a/packages/vscode-webdriverio/package.json
+++ b/packages/vscode-webdriverio/package.json
@@ -23,6 +23,10 @@
         "./parser/ast": {
             "requireSource": "./src/parser/ast.ts",
             "require": "./dist/parser/ast.cjs"
+        },
+        "./parser/cucumber": {
+            "requireSource": "./src/parser/cucumber.ts",
+            "require": "./dist/parser/cucumber.cjs"
         }
     },
     "scripts": {

--- a/packages/vscode-webdriverio/package.json
+++ b/packages/vscode-webdriverio/package.json
@@ -19,6 +19,10 @@
         "./reporter": {
             "requireSource": "./src/reporter.ts",
             "require": "./dist/reporter.cjs"
+        },
+        "./parser/ast": {
+            "requireSource": "./src/parser/ast.ts",
+            "require": "./dist/parser/ast.cjs"
         }
     },
     "scripts": {

--- a/packages/vscode-webdriverio/src/parser/ast.ts
+++ b/packages/vscode-webdriverio/src/parser/ast.ts
@@ -1,0 +1,1 @@
+export { createTempConfigFile } from '@vscode-wdio/worker/windows'

--- a/packages/vscode-webdriverio/src/parser/ast.ts
+++ b/packages/vscode-webdriverio/src/parser/ast.ts
@@ -1,1 +1,2 @@
 export { createTempConfigFile } from '@vscode-wdio/worker/windows'
+export { parseTestCases } from '@vscode-wdio/worker/parser/ast'

--- a/packages/vscode-webdriverio/src/parser/cucumber.ts
+++ b/packages/vscode-webdriverio/src/parser/cucumber.ts
@@ -1,0 +1,1 @@
+export { parseCucumberFeature } from '@vscode-wdio/worker/parser/cucumber'


### PR DESCRIPTION
Break down the modules executed by worker processes into the following units and dynamically load them as needed.
It separate into following modules.

- Cucumber parser
- AST parser (includes "Temp WDIO configuration file creator")



## Types of changes

[//]: # 'What types of changes does your code introduce to WebdriverIO?'
[//]: # '_Put an `x` in the boxes that apply_'

- [X] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # "_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._"

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/vscode-webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # 'If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...'

### Reviewers: @webdriverio/project-committers
