### PR TITLE
chore: use vscode.glob instead of glob

### DIFF
--- a/packages/vscode-wdio-config/package.json
+++ b/packages/vscode-wdio-config/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "@vscode-wdio/constants": "workspace:*",
     "@vscode-wdio/logger": "workspace:*",
-    "@vscode-wdio/utils": "workspace:*",
-    "glob": "^11.0.1"
+    "@vscode-wdio/utils": "workspace:*"
   },
   "devDependencies": {
     "@vscode-wdio/types": "workspace:*"

--- a/packages/vscode-wdio-config/src/find.ts
+++ b/packages/vscode-wdio-config/src/find.ts
@@ -1,24 +1,23 @@
 import fs from 'node:fs/promises'
-import path from 'node:path'
 
 import { log } from '@vscode-wdio/logger'
 import { normalizePath } from '@vscode-wdio/utils'
-import { glob } from 'glob'
+import * as vscode from 'vscode'
 
 export async function findWdioConfig(workSpaceRoot: string, configFilePattern: string[]) {
     log.debug(`Target workspace path: ${workSpaceRoot}`)
     log.debug(`Detecting the configuration file for WebdriverIO...: ${configFilePattern.join(', ')}`)
+    const globResult = await Promise.all(
+        configFilePattern.map((p) =>
+            vscode.workspace.findFiles(new vscode.RelativePattern(workSpaceRoot, p), '**/node_modules/**')
+        )
+    )
 
-    const wdioConfigPaths = await glob(configFilePattern, {
-        cwd: workSpaceRoot,
-        withFileTypes: false,
-        ignore: '**/node_modules/**',
-    })
+    const wdioConfigPaths = globResult.flatMap((uri) => uri).map((uri) => uri.fsPath)
 
     const configs = (
         await Promise.all(
-            wdioConfigPaths.map(async (_wdioConfigPath) => {
-                const wdioConfigPath = path.join(workSpaceRoot, _wdioConfigPath)
+            wdioConfigPaths.map(async (wdioConfigPath) => {
                 log.debug(`Checking the path: ${wdioConfigPath}`)
                 try {
                     await fs.access(wdioConfigPath, fs.constants.R_OK)

--- a/packages/vscode-wdio-config/tests/find.test.ts
+++ b/packages/vscode-wdio-config/tests/find.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { glob } from 'glob'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as vscode from 'vscode'
 
 import { findWdioConfig } from '../src/find.js'
 
@@ -10,7 +10,16 @@ import { findWdioConfig } from '../src/find.js'
 vi.mock('node:fs/promises')
 vi.mock('glob')
 
-vi.mock('vscode', async () => import('../../../tests/__mocks__/vscode.cjs'))
+vi.mock('vscode', async () => {
+    const vscode = await import('../../../tests/__mocks__/vscode.cjs')
+    return {
+        ...vscode,
+        RelativePattern: vi.fn(),
+        workspace: {
+            findFiles: vi.fn(),
+        },
+    }
+})
 vi.mock('@vscode-wdio/logger', () => import('../../../tests/__mocks__/logger.js'))
 
 describe('findWdioConfig', () => {
@@ -19,6 +28,13 @@ describe('findWdioConfig', () => {
 
     beforeEach(() => {
         vi.resetAllMocks()
+        vi.mocked(vscode.RelativePattern).mockImplementation(function (this: any, r: unknown, p: string) {
+            this.path = p
+            this.root = r
+            this.toString = function () {
+                return path.join(this.root, this.path)
+            }
+        } as any)
     })
 
     afterEach(() => {
@@ -30,9 +46,9 @@ describe('findWdioConfig', () => {
         const mockConfigFiles = ['wdio.conf.js', 'wdio.conf.ts']
         const expectedPaths = mockConfigFiles.map((file) => path.join(mockWorkspaceRoot, file))
 
-        // Mock glob to return the config files
-        vi.mocked(glob).mockResolvedValue(mockConfigFiles)
-
+        vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p: vscode.GlobPattern) => {
+            return [vscode.Uri.file(p.toString())]
+        })
         // Mock fs.access to succeed for all files
         vi.mocked(fs.access).mockResolvedValue(undefined)
 
@@ -41,21 +57,22 @@ describe('findWdioConfig', () => {
 
         // Verify
         expect(result).toEqual(expectedPaths)
-        expect(glob).toHaveBeenCalledWith(defaultConfigFilePattern, {
-            cwd: mockWorkspaceRoot,
-            withFileTypes: false,
-            ignore: '**/node_modules/**',
-        })
         expect(fs.access).toHaveBeenCalledTimes(2)
     })
 
     it('should filter out inaccessible files', async () => {
         // Setup
-        const mockConfigFiles = ['wdio.conf.js', 'wdio.conf.ts']
         const accessibleFile = path.join(mockWorkspaceRoot, 'wdio.conf.js')
 
-        // Mock glob to return the config files
-        vi.mocked(glob).mockResolvedValue(mockConfigFiles)
+        // vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p:vscode.GlobPattern)=>{
+        //     if (p.toString() === accessibleFile) {
+        //         return [vscode.Uri.file(p.toString())]
+        //     }
+        //     return []
+        // })
+        vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p: vscode.GlobPattern) => {
+            return [vscode.Uri.file(p.toString())]
+        })
 
         // Mock fs.access to succeed only for the JS file
         vi.mocked(fs.access).mockImplementation(async (filePath) => {
@@ -75,10 +92,9 @@ describe('findWdioConfig', () => {
 
     it('should return empty array when no config files are accessible', async () => {
         // Setup
-        const mockConfigFiles = ['wdio.conf.js', 'wdio.conf.ts']
-
-        // Mock glob to return the config files
-        vi.mocked(glob).mockResolvedValue(mockConfigFiles)
+        vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p: vscode.GlobPattern) => {
+            return [vscode.Uri.file(p.toString())]
+        })
 
         // Mock fs.access to fail for all files
         vi.mocked(fs.access).mockRejectedValue(new Error('File not found'))
@@ -93,8 +109,7 @@ describe('findWdioConfig', () => {
 
     it('should handle empty glob results', async () => {
         // Setup
-        // Mock glob to return no files
-        vi.mocked(glob).mockResolvedValue([])
+        vi.mocked(vscode.workspace.findFiles).mockResolvedValue([])
 
         // Execute
         const result = await findWdioConfig(mockWorkspaceRoot, defaultConfigFilePattern)
@@ -102,29 +117,5 @@ describe('findWdioConfig', () => {
         // Verify
         expect(result).toEqual([])
         expect(fs.access).not.toHaveBeenCalled()
-    })
-
-    it('should use custom config file pattern when provided', async () => {
-        // Setup
-        const customConfigPattern = ['custom.wdio.conf.js']
-        const mockConfigFiles = ['custom.wdio.conf.js']
-        const expectedPaths = mockConfigFiles.map((file) => path.join(mockWorkspaceRoot, file))
-
-        // Mock glob to return the config files
-        vi.mocked(glob).mockResolvedValue(mockConfigFiles)
-
-        // Mock fs.access to succeed
-        vi.mocked(fs.access).mockResolvedValue(undefined)
-
-        // Execute
-        const result = await findWdioConfig(mockWorkspaceRoot, customConfigPattern)
-
-        // Verify
-        expect(result).toEqual(expectedPaths)
-        expect(glob).toHaveBeenCalledWith(customConfigPattern, {
-            cwd: mockWorkspaceRoot,
-            withFileTypes: false,
-            ignore: '**/node_modules/**',
-        })
     })
 })

--- a/packages/vscode-wdio-config/tests/find.test.ts
+++ b/packages/vscode-wdio-config/tests/find.test.ts
@@ -64,12 +64,6 @@ describe('findWdioConfig', () => {
         // Setup
         const accessibleFile = path.join(mockWorkspaceRoot, 'wdio.conf.js')
 
-        // vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p:vscode.GlobPattern)=>{
-        //     if (p.toString() === accessibleFile) {
-        //         return [vscode.Uri.file(p.toString())]
-        //     }
-        //     return []
-        // })
         vi.mocked(vscode.workspace.findFiles).mockImplementation(async (p: vscode.GlobPattern) => {
             return [vscode.Uri.file(p.toString())]
         })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       '@vscode-wdio/utils':
         specifier: workspace:*
         version: link:../vscode-wdio-utils
-      glob:
-        specifier: ^11.0.1
-        version: 11.0.3
     devDependencies:
       '@vscode-wdio/types':
         specifier: workspace:*

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,21 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, defaultExclude } from 'vitest/config'
 
 export default defineConfig({
+    // https://github.com/vitest-dev/vitest/discussions/6662
+    server: {
+        watch: {
+            ignored: ['**/dist/**'],
+        },
+    },
+
     test: {
+        projects: ['packages/*'],
         dangerouslyIgnoreUnhandledErrors: true,
         include: ['packages/**/*.test.ts'],
         /**
          * not to ESM ported packages
          */
-        exclude: ['dist', 'out', 'coverage', '.idea', '.git', '.vscode-test', '.cache', '**/node_modules/**'],
+        exclude: [...defaultExclude, '**/coverage/**', '.vscode-test'],
         env: {
             WDIO_UNIT_TESTING: '1',
         },
@@ -17,7 +25,7 @@ export default defineConfig({
             include: ['packages/*/src/**'],
             provider: 'v8',
             reportOnFailure: true,
-            exclude: ['**/node_modules/**', 'packages/wdio-vscode-types/src/**'],
+            exclude: [...defaultExclude, 'packages/wdio-vscode-types/src/**'],
             watermarks: {
                 statements: [85, 90],
                 functions: [83, 88],


### PR DESCRIPTION
## Proposed changes

Use `vscode.glob` instead of `glob`.

## Types of changes

[//]: # 'What types of changes does your code introduce to WebdriverIO?'
[//]: # '_Put an `x` in the boxes that apply_'

- [X] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # "_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._"

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/vscode-webdriverio/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # 'If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...'

### Reviewers: @webdriverio/project-committers
