### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   close-not-reproducible-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 
 on:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: E2E tests
 
 on:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Static code analysis
 
 on:

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Smoke tests
 
 on:

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -5,6 +5,9 @@ on:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
 
+permissions:
+  contents: read
+
 env:
   TURBO_TELEMETRY_DISABLED: 1
 

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Unit tests
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -124,5 +124,5 @@ export async function collapseAllTests(testingSection: DefaultTreeSection) {
 }
 
 export function resetFileChange(filePath: string) {
-    shell.exec(`git checkout ${filePath}`, { silent: true })
+    shell.cmd('git', 'checkout', filePath)
 }


### PR DESCRIPTION
## Proposed changes

To fix the problem, add an explicit `permissions` block with the minimal required permissions for the workflow. Since the job only checks out code, sets up the workspace, downloads an archive, and runs tests (with no need to write to the repository or interact with pull requests/issues), the correct minimal permission is `contents: read`. This can be added at the root of the workflow file 

## Types of changes

[//]: # 'What types of changes does your code introduce to WebdriverIO?'
[//]: # '_Put an `x` in the boxes that apply_'

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [X] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # "_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._"

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/vscode-webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # 'If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...'

### Reviewers: @webdriverio/project-committers
