### PR TITLE
chore: update VS Code js/ts autoDetect settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,8 @@
     "dist": true // set this to false to include "dist" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
-  "typescript.preferences.importModuleSpecifierEnding": "js",
+  "js/ts.tsc.autoDetect": "off",
+  "js/ts.preferences.importModuleSpecifierEnding": "js",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.format.enable": true,


### PR DESCRIPTION
## Proposed changes
[//]: # 'Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.'
Update workspace VS Code settings in `settings.json` to use the current `js/ts.*` keys for auto-detection and import module specifier ending. This corrects the VS Code configuration to match the modern JavaScript/TypeScript settings schema.

## Types of changes
[//]: # 'What types of changes does your code introduce to WebdriverIO?'
[//]: # '_Put an `x` in the boxes that apply_'

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [x] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist
[//]: # "_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._"

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/vscode-webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments
[//]: # 'If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...'
This change is limited to the editor workspace settings and does not affect runtime behavior of the extension or tests.

### Reviewers: @webdriverio/project-committers